### PR TITLE
Added deep_compact to Attr and TagAttr to avoid nil or empty objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.1 - 2020-01-08
+
+- Fix: added `deep_compact` to Attr and TagAttr to ensure that `nil` or `empty?` objects are ignored.
+
 # v1.0.0 - 2019-12-18
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spark-component (1.0.0)
+    spark-component (1.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -42,7 +42,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    actionview-component (1.5.3)
+    actionview-component (1.6.1)
     activejob (6.0.1)
       activesupport (= 6.0.1)
       globalid (>= 0.3.6)

--- a/lib/spark/component/attr.rb
+++ b/lib/spark/component/attr.rb
@@ -11,6 +11,7 @@ module Spark
       def add(hash)
         return self if hash.nil? || hash.keys.empty?
 
+        deep_compact!(hash)
         dasherize_keys(hash)
         merge!(hash)
         self
@@ -31,6 +32,17 @@ module Spark
       end
 
       private
+
+      def deep_compact!(hash)
+        hash.replace(deep_compact(hash))
+      end
+
+      def deep_compact(hash)
+        hash.select do |key, val|
+          val = deep_compact(val) if val.is_a?(Hash)
+          !(val.nil? || val.respond_to?(:empty?) && val.empty?)
+        end
+      end
 
       def dasherize_keys(hash)
         hash.merge!(hash.keys.each_with_object({}) do |key, obj|

--- a/lib/spark/component/tag_attr.rb
+++ b/lib/spark/component/tag_attr.rb
@@ -9,6 +9,8 @@ module Spark
       def add(hash)
         return self if hash.nil? || hash.keys.empty?
 
+        deep_compact!(hash)
+
         # Extract keys for special properties
         extracted = {
           aria: hash.delete(:aria),

--- a/lib/spark/component/version.rb
+++ b/lib/spark/component/version.rb
@@ -2,6 +2,6 @@
 
 module Spark
   module Component
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/test/spark/attr_test.rb
+++ b/test/spark/attr_test.rb
@@ -34,6 +34,13 @@ module Spark
 
         assert_equal "foo-bar", hash.keys.first
       end
+
+      def test_does_not_allow_nil_attributes
+        hash = Attr.new
+        hash.add({ id: "hi", class: [], data: { foo: nil }, aria: nil, string: '' })
+
+        assert_equal({:id=>"hi"}, hash)
+      end
     end
   end
 end

--- a/test/spark/tag_attr_test.rb
+++ b/test/spark/tag_attr_test.rb
@@ -70,6 +70,13 @@ module Spark
 
         assert_equal %(aria-a="1" class="hi there" data-b="2" id="some_id"), tag_attr.to_s
       end
+
+      def test_does_not_allow_nil_attributes
+        hash = TagAttr.new
+        hash.add({ id: "hi", class: [], data: { foo: nil }, aria: nil, string: '' })
+
+        assert_equal({:id=>"hi"}, hash)
+      end
     end
   end
 end


### PR DESCRIPTION
Before adding nil or empty objects to an Attr hash or TagAttr worked. Now these objects stay clean.
```ruby
hash = Attr.new
hash.add({ id: "hi", class: [], data: { foo: nil }, aria: nil, string: '' })

# hash => {:id=>"hi"}
```