### PR TITLE
Attribute default groups assign defaults to attributes from a single argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.1.0 - 2020-01-10
+
+- New: Class method `attribute_default_group` makes it easy to set defaults for multiple attributes based on a single component argument. It's great for theming, where setting `theme: :notice` can set attributes for color, layout, etc.
+- New: Class methods `tag_attribute`, `data_attribute`, and `aria_attribute` make it easy to sync component arguments to tag_attrs object.
+
 # v1.0.1 - 2020-01-08
 
 - Fix: added `deep_compact` to Attr and TagAttr to ensure that `nil` or `empty?` objects are ignored.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spark-component (1.0.1)
+    spark-component (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/spark/component/version.rb
+++ b/lib/spark/component/version.rb
@@ -2,6 +2,6 @@
 
 module Spark
   module Component
-    VERSION = "1.0.1"
+    VERSION = "1.1.0"
   end
 end

--- a/test/spark/attribute_test.rb
+++ b/test/spark/attribute_test.rb
@@ -174,6 +174,39 @@ module Spark
         assert_equal(tag_attrs, klass_instance.tag_attrs)
       end
 
+      def test_attribute_default_group_assigns_defaults
+        klass = base_class
+        klass.attribute bar: "toast", theme: :a
+
+        klass.attribute_default_group(theme: {
+                                        a: { bar: true, baz: false },
+                                        b: { baz: true }
+                                      })
+
+        expected = { bar: "true", theme: :a }
+        assert_equal expected, klass.new.attributes
+
+        klass_instance = klass.new(theme: :b)
+        expected = { bar: "toast", theme: :b }
+        assert_equal expected, klass_instance.attributes
+        assert_equal true, klass_instance.instance_variable_get(:"@baz")
+      end
+
+      def test_attribute_default_group_raises_an_error_for_improperly_formed_groups
+        klass = base_class
+        klass.attribute :theme
+
+        klass.attribute_default_group(theme: { test: true })
+
+        exception = assert_raises(RuntimeError) do
+          klass.new(theme: :test)
+        end
+
+        message = "In argument group `:test`, value `true` must be a hash."
+
+        assert_includes message, exception.message
+      end
+
       def test_validates_attrs_raises_exception
         klass = base_class
         klass.attribute :foo


### PR DESCRIPTION
Attribute default groups are an easy way to tie together multiple attribute defaults under a single argument. Here's an example.

```ruby
class ButtonComponent < ActionView::Component::Base
  include Spark::Component
  attribute :theme, :color, :confirm, :type, :text
  
  # Create a group of attribute defaults to tie properties together under the `theme` attribute.
  attribute_default_group(theme: {
    primary: {
      color: :blue,
      type: :submit,
      text: "Save"
    },
    danger: {
      color: :red,
      confirm: "Are you sure?",
      text: "Delete"
    }
  })
end
```

This will allow a user to set `theme: :primary` instead of having to set `color`, `type`, `text`, and `confirm` individually.