### PR TITLE
Misc fixes for element rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.1.1 - 2020-01-14
+
+- Fix: When a nested element is referenced it will trigger the parent to yield
+    its block, ensuring that the nested element reference will be instantiated
+    if it is used in the parent's block.
+- Fix: Elements now have a `blank?` method and `present?` returns `!blank?`. It
+    is important to remember, `blank?` and `present?` return false if an element
+    yields nothing. To check for the existence of an element instance, use `nil?`.
+- New: Elements now have access to their own name with the `_name` method.
+
 # v1.1.0 - 2020-01-10
 
 - New: Class method `attribute_default_group` makes it easy to set defaults for multiple attributes based on a single component argument. It's great for theming, where setting `theme: :notice` can set attributes for color, layout, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spark-component (1.1.0)
+    spark-component (1.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -42,7 +42,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    actionview-component (1.6.1)
+    actionview-component (1.7.0)
     activejob (6.0.1)
       activesupport (= 6.0.1)
       globalid (>= 0.3.6)

--- a/lib/spark/component/version.rb
+++ b/lib/spark/component/version.rb
@@ -2,6 +2,6 @@
 
 module Spark
   module Component
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end

--- a/test/app/components/element_component.html.slim
+++ b/test/app/components/element_component.html.slim
@@ -11,3 +11,7 @@
   = component_config_validation.yield
 - if with_elements.present?
   = with_elements.yield
+- if simple_parent_el && simple_parent_el.simple_child_el.present?
+    #child= simple_parent_el.simple_child_el.yield
+- if h3.present?
+  = content_tag(h3._name, h3.yield)

--- a/test/app/components/element_component.rb
+++ b/test/app/components/element_component.rb
@@ -13,9 +13,15 @@ class ElementComponent < ActionView::Component::Base
     end
   end
 
+  element :simple_parent_el do
+    element :simple_child_el
+  end
+
   element :component_config_validation, component: AttributeComponent do
     validates_attr :a, numericality: { only_integer: true }
   end
+
+  element :h3
 
   def initialize(*)
     super

--- a/test/app/components/simple_component.html.slim
+++ b/test/app/components/simple_component.html.slim
@@ -1,1 +1,1 @@
-div test
+div *tag_attrs = content

--- a/test/app/components/simple_component.rb
+++ b/test/app/components/simple_component.rb
@@ -1,7 +1,7 @@
 class SimpleComponent < ActionView::Component::Base
   include Spark::Component
 
-  def initilize(*)
+  def initialize(*)
     super
   end
 end

--- a/test/app/views/application/component_with_element_referencing_name.html.slim
+++ b/test/app/views/application/component_with_element_referencing_name.html.slim
@@ -1,0 +1,3 @@
+= render ElementComponent do |c|
+  - c.h3 do |h3|
+    |Title

--- a/test/app/views/application/component_with_nested_plain_elements.html.slim
+++ b/test/app/views/application/component_with_nested_plain_elements.html.slim
@@ -1,0 +1,4 @@
+= render ElementComponent do |c|
+  - c.simple_parent_el do |el|
+    - el.simple_child_el
+      |hello parent

--- a/test/spark/element_test.rb
+++ b/test/spark/element_test.rb
@@ -99,5 +99,19 @@ module Spark
       assert_includes html, %(<li><div>2</div></li>)
       assert_includes html, %(<li><div>3</div></li>)
     end
+
+    def test_element_yields_if_nested_element_is_called
+      get "/component_with_nested_plain_elements"
+      assert_response :success
+      html = get_html(response.body)
+      assert_includes html, %(<div id="child">hello parent</div>)
+    end
+
+    def test_element_can_reference_its_own_name
+      get "/component_with_element_referencing_name"
+      assert_response :success
+      html = get_html(response.body)
+      assert_includes html, %(<h3>Title</h3>)
+    end
   end
 end


### PR DESCRIPTION
- Elements with sub elements need to have their blocks yielded to
instantiate sub elements. Now sub element methods trigger yield on
their parent if they haven't been yielded yet.

- Elements now have access to their own names via the `_name` method.
- ELements now define `_blank?` which tells if they yield `nil` or yield `empty?` strings.