### PR TITLE
Guard component rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# v1.1.1 - 2020-01-14
+# v1.1.2 - 2020-01-14
+- Fix: Added render checking to component to prevent executing `render_self` more than once. 
 
+# v1.1.1 - 2020-01-14
 - Fix: When a nested element is referenced it will trigger the parent to yield
     its block, ensuring that the nested element reference will be instantiated
     if it is used in the parent's block.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spark-component (1.1.1)
+    spark-component (1.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/spark/component/element.rb
+++ b/lib/spark/component/element.rb
@@ -38,12 +38,13 @@ module Spark
       end
 
       def render_self
-        return @content if rendered?
+        # Guard with `rendered?` boolean in case render_block returns `nil`
+        return @render_self if rendered?
 
-        @content = render_block(@view_context, &_block)
+        @render_self = render_block(@view_context, &_block)
         validate! if defined?(ActiveModel::Validations)
         @rendered = true
-        @content
+        @render_self
       end
 
       def rendered?

--- a/lib/spark/component/integration/action_view_component.rb
+++ b/lib/spark/component/integration/action_view_component.rb
@@ -34,7 +34,11 @@ module Spark
       end
 
       def render_self
-        render_in(@view_context, &@_block)
+        # Guard with `rendered?` boolean in case render_block returns `nil`
+        return @render_self if rendered?
+
+        @rendered = true
+        @render_self = render_in(@view_context, &@_block)
       end
 
       # Override class methods for components

--- a/lib/spark/component/version.rb
+++ b/lib/spark/component/version.rb
@@ -2,6 +2,6 @@
 
 module Spark
   module Component
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end


### PR DESCRIPTION
This fixes a bug where before, checking `present?` on an `actionview-component` could trigger its `yield` method, causing and additional render. To fix a guard clause was added to the `render_self` method for those components.