### PR TITLE
Extending components should extend tag, data, aria attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.1.3 - 2020-01-15
+- Fix: Extending a component will now extend its class defined tag attributes, aria attributes, and data attributes.
+
 # v1.1.2 - 2020-01-14
 - Fix: Added render checking to component to prevent executing `render_self` more than once. 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spark-component (1.1.2)
+    spark-component (1.1.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/spark/component/element.rb
+++ b/lib/spark/component/element.rb
@@ -111,8 +111,11 @@ module Spark
 
       module ClassMethods
         def inherited(child)
-          child.elements.replace(elements.merge(child.elements))
-          child.attributes.replace(attributes.merge(child.attributes))
+          child.elements.replace(elements)
+          child.attributes.replace(attributes)
+          child.tag_attributes.replace(tag_attributes)
+          child.data_attributes.replace(data_attributes)
+          child.aria_attributes.replace(aria_attributes)
         end
 
         def elements

--- a/lib/spark/component/version.rb
+++ b/lib/spark/component/version.rb
@@ -2,6 +2,6 @@
 
 module Spark
   module Component
-    VERSION = "1.1.2"
+    VERSION = "1.1.3"
   end
 end

--- a/test/spark/element_test.rb
+++ b/test/spark/element_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "spark/component/element"
 
 module Spark
   class ElementIntegrationTest < ActionDispatch::IntegrationTest
@@ -65,6 +64,49 @@ module Spark
       assert_response :success
       assert_equal %(<div class="block">block</div>), get_html(response.body, css: ".block")
       assert_equal %(<strong>hi</strong>), get_html(response.body, css: "strong")
+    end
+
+    def test_inherit_tag_attributes_when_extending_class
+      klass = Class.new do
+        include Component::Attribute
+        include Component::Element
+        tag_attribute zeep: :zorp
+      end
+
+      extended = Class.new(klass)
+      instance = extended.new
+
+      assert extended.tag_attributes.include?(:zeep)
+
+      assert_equal :zorp, instance.tag_attrs[:zeep]
+    end
+
+    def test_inherit_aria_attributes_when_extending_class
+      klass = Class.new do
+        include Component::Attribute
+        include Component::Element
+        aria_attribute meep: :morp
+      end
+
+      extended = Class.new(klass)
+      instance = extended.new
+
+      assert extended.aria_attributes.include?(:meep)
+      assert_equal :morp, instance.aria[:meep]
+    end
+
+    def test_inherit_data_attributes_when_extending_class
+      klass = Class.new do
+        include Component::Attribute
+        include Component::Element
+        data_attribute bleep: :blorp
+      end
+
+      extended = Class.new(klass)
+      instance = extended.new
+
+      assert extended.data_attributes.include?(:bleep)
+      assert_equal :blorp, instance.data[:bleep]
     end
 
     def test_render_element_config_extending_component


### PR DESCRIPTION
When a class extends another class which has defined tag_attributes, aria_attributes, and data_attributes as enabled in #3, the new class will now inherit those attributes.