### PR TITLE
Minor improvements to attribute default methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.1.4 - 2020-01-28
+- Fix: attrtibute_default_group now accepts booleans and normalizes keys.
+- Fix: element_attribute_default now merges attributes.
+
 # v1.1.3 - 2020-01-15
 - Fix: Extending a component will now extend its class defined tag attributes, aria attributes, and data attributes.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spark-component (1.1.3)
+    spark-component (1.1.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/spark/component/attribute.rb
+++ b/lib/spark/component/attribute.rb
@@ -75,12 +75,34 @@ module Spark
         end
       end
 
+      # Takes attributes passed to a component or element and assigns values to other
+      # attributes as defined in their group.
+      #
+      # For example, with an attribute group:
+      #   theme: {
+      #     notice: { icon: "message", color: "blue" }
+      #     error: { icon: "error", color: "red" }
+      #   }
+      #
+      # If the attributes include `theme: :notice`, the icon and color attributes
+      # would default to "message" and "blue", but could be overriden if the user
+      # set values for them.
+      #
       def initialize_attribute_default_groups(attrs)
         self.class.attribute_default_groups.each do |group, group_options|
           # Determine what group name is set for this attribute.
+          # In the above example the group would be `theme` and the name
+          # would be the value passed for `theme`, or its default value.
+          #
+          # So `name` might be `:notice`.
           name = attrs[group] || self.class.attributes[group]
 
+          # Normalize name for hash lookup. to_s.to_sym converts booleans as well.
+          name = name.to_s.to_sym unless name.nil?
+
           # Get defaults to set from group name
+          # In the above example, if the name were `notice` this would be the hash
+          # `{ icon: "message", color: "blue" }`
           defaults = group_options[name]
 
           next unless defaults

--- a/lib/spark/component/element.rb
+++ b/lib/spark/component/element.rb
@@ -95,7 +95,8 @@ module Spark
 
       # Override the default value for an element's attribute(s)
       def set_element_attribute_default(element, attrs = {})
-        element_attribute_default[element] = attrs
+        element_attribute_default[element] ||= {}
+        element_attribute_default[element].merge!(attrs)
       end
 
       def element_attribute_default

--- a/lib/spark/component/version.rb
+++ b/lib/spark/component/version.rb
@@ -2,6 +2,6 @@
 
 module Spark
   module Component
-    VERSION = "1.1.3"
+    VERSION = "1.1.4"
   end
 end

--- a/test/spark/attribute_test.rb
+++ b/test/spark/attribute_test.rb
@@ -192,6 +192,21 @@ module Spark
         assert_equal true, klass_instance.instance_variable_get(:"@baz")
       end
 
+      def test_attribute_default_group_with_boolean_keys
+        klass = base_class
+        klass.attribute :foo
+
+        klass.attribute_default_group(foo: {
+                                        true: { bar: true, baz: false } # rubocop:disable Lint/BooleanSymbol
+                                      })
+
+        klass_instance = klass.new(foo: true)
+        expected = { foo: "true" }
+        assert_equal expected, klass_instance.attributes
+        assert_equal true, klass_instance.instance_variable_get(:"@bar")
+        assert_equal false, klass_instance.instance_variable_get(:"@baz")
+      end
+
       def test_attribute_default_group_raises_an_error_for_improperly_formed_groups
         klass = base_class
         klass.attribute :theme


### PR DESCRIPTION
Using `set_attribute_default` multiple times now merges, rather than
replacing objects. This will allow extended components to add to default
atributes.

Now attribute_default_group can handle boolean attributes. This allows
using a boolean attribute to set groups of other attributes.

For example:

```
set_attribute_default(fit: { true: { nowrap: true, size: :xs }})
```

This will set the values for `nowrap` and `size` when `fit: true` is
passed as element or component arguements or set as a default value.